### PR TITLE
changed `get_r200_angsize_and_c200`

### DIFF
--- a/deepszsim/make_sz_cluster.py
+++ b/deepszsim/make_sz_cluster.py
@@ -410,7 +410,7 @@ def generate_y_submap(M200_SM, redshift_z, profile = "Battaglia2012",
 
     return y_map
 
-def get_r200_angsize_and_c200(M200_SM, redshift_z, load_vars_dict):
+def get_r200_angsize_and_c200(M200_SM, redshift_z, load_vars_dict, angsize_density = None):
     '''
     Parameters:
     ----------
@@ -439,9 +439,19 @@ def get_r200_angsize_and_c200(M200_SM, redshift_z, load_vars_dict):
     cosmology.addCosmology('myCosmo', **params)
     cosmo_colossus = cosmology.setCosmology('myCosmo')
     
-    M200_SM, R200_Mpc, c200 = mass_adv.changeMassDefinitionCModel(M200_SM * cosmo.h,
+    M200_SM, R200_kpc, c200 = mass_adv.changeMassDefinitionCModel(M200_SM * cosmo.h,
                                                                   redshift_z, '200c', '200c', c_model = 'ishiyama21')
     M200_SM /= cosmo.h  # From M_solar/h to M_solar
-    R200_Mpc = R200_Mpc / cosmo.h / 1000  # From kpc/h to Mpc
-    angsize_arcmin = R200_Mpc*1000/60/cosmo_colossus.kpcPerArcsec(redshift_z)
+    R200_Mpc = R200_kpc / cosmo.h / 1000  # From kpc/h to Mpc
+    
+    if angsize_density is not None:
+        if angsize_density != '200c':
+            _, Rd_kpc, _ = mass_adv.changeMassDefinitionCModel(M200_SM * cosmo.h,
+                                                               redshift_z, '200c', angsize_density,
+                                                               c_model = 'ishiyama21')
+            angsize_arcmin = Rd_kpc / cosmo.h / 60 / cosmo_colossus.kpcPerArcsec(redshift_z)
+        else:
+            angsize_arcmin = R200_Mpc * 1000 / 60 / cosmo_colossus.kpcPerArcsec(redshift_z)
+    else:
+        angsize_arcmin = None
     return M200_SM, R200_Mpc, angsize_arcmin, c200 # now returns M200, R200, angsize in arcmin, c200

--- a/deepszsim/simclusters.py
+++ b/deepszsim/simclusters.py
@@ -93,8 +93,9 @@ class simulate_clusters:
         if R200_Mpc is not None:
             self.R200_Mpc = R200_Mpc
         else:
-            self.R200_Mpc, self.angsize_arcmin = np.array(
-                [make_sz_cluster.get_r200_angsize_and_c200(self.M200[i], self.redshift_z[i], self.vars)[1:-1]
+            self.R200_Mpc, self.angsize500_arcmin = np.array(
+                [make_sz_cluster.get_r200_angsize_and_c200(self.M200[i], self.redshift_z[i], self.vars,
+                                                           angsize_density = '500c')[[1,2]]
                  for i in range(self._size)]).T
         
         self.Rmaxy = Rmaxy
@@ -104,7 +105,7 @@ class simulate_clusters:
             for i in range(self._size)]
         self.clusters.update(zip(self.id_list, [{"params": {'M200': self.M200[i], 'redshift_z': self.redshift_z[i],
                                                             'R200': self.R200_Mpc[i],
-                                                            'angsize_arcmin': self.angsize_arcmin[i],
+                                                            'angsize500_arcmin': self.angsize500_arcmin[i],
                                                             'image_size_pixels': self.image_size_pixels}} for
                                                 i in range(
                 self._size)]))

--- a/tests/test_szcluster.py
+++ b/tests/test_szcluster.py
@@ -148,9 +148,9 @@ class TestSZCluster:
         M200_SM = 1e14
         redshift_z = 1
         R200_expected = 0.6832978084398144
-        angsize_arcmin_expected = 1.3786496285878964
+        angsize_arcmin_expected = 0.8908671948201962
         c200_expected = 3.5527260646787737
-        result = get_r200_angsize_and_c200(M200_SM, redshift_z, {'cosmo': cosmo, 'sigma8': 0.8, 'ns': 0.96})
+        result = get_r200_angsize_and_c200(M200_SM, redshift_z, {'cosmo': cosmo, 'sigma8': 0.8, 'ns': 0.96}, angsize_density = '500c')
         assert np.isclose(result[1], R200_expected), f"Expected {R200_expected}, but got {result[1]}"
         assert np.isclose(result[2], angsize_arcmin_expected), f"Expected {angsize_arcmin_expected}, but got {result[2]}"
         assert np.isclose(result[-1], c200_expected), f"Expected {c200_expected}, but got {result[-1]}"


### PR DESCRIPTION
made it so that the 2 entry of the return of `get_r200_angsize_and_c200` returns `None` by default, and need to specify which radius is of interest to store for the cluster

The reason for this change is that it turns out that we are interested in using R500 (instead of R200) to characterize the angular size of the clusters, since this matches the observational literature better and corresponds "by eye" to the edge of the cluster edge better. This will also make a stronger aperture photometry signal. To get this, one would do `get_r200_angsize_and_c200(M200, z, load_vars_instance, angsize_density='500c')`, which is now the default behavior in `simclusters.simulate_clusters`